### PR TITLE
newrelic_disable_autorum() on ajax and cron

### DIFF
--- a/components/class-go-newrelic.php
+++ b/components/class-go-newrelic.php
@@ -52,6 +52,7 @@ class GO_NewRelic
 			if ( defined( 'DOING_AJAX' ) && DOING_AJAX )
 			{
 				newrelic_set_appname( $app_name . ' ajax' );
+				newrelic_disable_autorum();
 			}
 			else
 			{
@@ -60,7 +61,8 @@ class GO_NewRelic
 		}
 		elseif ( defined( 'DOING_CRON' ) && DOING_CRON )
 		{
-				newrelic_set_appname( $app_name . ' cron' );
+			newrelic_set_appname( $app_name . ' cron' );
+			newrelic_disable_autorum();
 		}
 		else
 		{


### PR DESCRIPTION
`newrelic_disable_autorum()` on ajax and cron to prevent the NR JS from appearing on the page.

Maybe addresses https://github.com/GigaOM/legacy-pro/issues/3571

Docs at https://docs.newrelic.com/docs/php/php-agent-api :

> `newrelic_disable_autorum (  )`
> 
> Prevents the output filter from attempting to insert the JavaScript for page load timing (sometimes referred to as real user monitoring or RUM) for this current transaction.
