### PR TITLE
delay initialization until plugins loaded

### DIFF
--- a/go-newrelic.php
+++ b/go-newrelic.php
@@ -10,4 +10,5 @@
 
 // include required components
 require_once dirname( __FILE__ ) .'/components/class-go-newrelic.php';
-go_newrelic();
+add_action( 'plugins_loaded', 'go_newrelic', 0, 0 );
+


### PR DESCRIPTION
If you have the plugin network activated and you're using SSL for the admin,
loading any admin page will give a notice that the global `$pagenow` is not
defined.

Notice: Undefined index: pagenow in /srv/www/default/application/wp/wp-includes/link-template.php on line 2451

The global is setup after network-active plugins load, but before blog
plugins load, and it's used in `get_home_url()` on SSL requests.
