### PR TITLE
going back to wp_head

### DIFF
--- a/components/class-go-newrelic-browser.php
+++ b/components/class-go-newrelic-browser.php
@@ -12,7 +12,7 @@ class GO_NewRelic_Browser
 		if ( $this->settings )
 		{
 			// New Relic claims we are not tracking because the code should occur before any other scripts in the head, let's move it up!
-			add_action( 'go_newrelic_browser', array( $this, 'output_browser_tracking_code' ) );
+			add_action( 'wp_head', array( $this, 'output_browser_tracking_code' ) );
 			// admin_print_scripts is more appropriate, but this needs to happed as soon as possible
 			add_action( 'admin_enqueue_scripts', array( $this, 'output_browser_tracking_code' ), 0 );
 		}//end if


### PR DESCRIPTION
Turned out that timing was not the core issue here.  moving back to wp_head.  This is working in this way in production now.

See: https://github.com/GigaOM/gigaom/issues/6072
